### PR TITLE
get bs_module from sys.modules, not directly from `__import__`()

### DIFF
--- a/django_beanstalkd/decorators.py
+++ b/django_beanstalkd/decorators.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+import sys
+
 class beanstalk_job(object):
     """
     Decorator marking a function inside some_app/beanstalk_jobs.py as a
@@ -5,9 +8,11 @@ class beanstalk_job(object):
     """
 
     def __init__(self, f):
+        modname = f.__module__
         self.f = f
         self.__name__ = f.__name__
-        
+        self.__module__ = modname
+
         # determine app name
         parts = f.__module__.split('.')
         if len(parts) > 1:
@@ -16,7 +21,8 @@ class beanstalk_job(object):
             self.app = ''
 
         # store function in per-app job list (to be picked up by a worker)
-        bs_module = __import__(f.__module__)
+        __import__(modname)
+        bs_module = sys.modules[modname]
         try:
             if self not in bs_module.beanstalk_job_list:
                 bs_module.beanstalk_job_list.append(self)

--- a/django_beanstalkd/management/commands/beanstalk_worker.py
+++ b/django_beanstalkd/management/commands/beanstalk_worker.py
@@ -33,7 +33,9 @@ class Command(NoArgsCommand):
         bs_modules = []
         for app in settings.INSTALLED_APPS:
             try:
-                bs_modules.append(__import__("%s.beanstalk_jobs" % app))
+                modname = "%s.beanstalk_jobs" % app
+                __import__(modname)
+                bs_modules.append(sys.modules[modname])
             except ImportError:
                 pass
         if not bs_modules:
@@ -108,7 +110,7 @@ class Command(NoArgsCommand):
         for job in self.jobs.keys():
             beanstalk.watch(job)
         beanstalk.ignore('default')
-        
+
         try:
             while True:
                 job = beanstalk.reserve()
@@ -133,6 +135,6 @@ class Command(NoArgsCommand):
                         job.delete()
                 else:
                     job.release()
-            
+
         except KeyboardInterrupt:
             sys.exit(0)


### PR DESCRIPTION
`__import__()` returns the top-level module of a package, not the module itself. `__import__()` + `sys.modules` is the way recommanded by the python documentation:

http://docs.python.org/library/functions.html#__import__ (see last example)

My django packages are in a nested namespace (2 levels): top.package1, top.package2,...

Without this patch, the job list is located in "top" module, and the jobs are listed twice (or more if you have more packages in "top.*" and beanstalk jobs. This can be confusing for the user, although jobs are properly registered.

With my patch, the job list is properly locate in top.package.1.beanstalk_jobs, top.package2.beanstalk_jobs, and so on.

I have also set `__module__` attribute of the decorator to reflect `__module__` attribute of the decorated function (not exactly a clean functools.wraps, but it can help debugging)
