### PR TITLE
Fixed for compatibility with Django 1.10.x

### DIFF
--- a/beanstalk_example/management/commands/beanstalk_example_client.py
+++ b/beanstalk_example/management/commands/beanstalk_example_client.py
@@ -1,12 +1,12 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django_beanstalkd import BeanstalkClient
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Execute an example command with the django_beanstalk_jobs interface"
     __doc__ = help
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         client = BeanstalkClient()
 
         print "Asynchronous Beanstalk Call"


### PR DESCRIPTION
Changed from NoArgsCommand to BaseCommand, which takes no arguments by
default.
NoArgsCommand is deprecated as of 1.10.